### PR TITLE
Added other search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,30 @@ None.
 ## Configuration
 
 ```yaml
-- name: google-it
-  # Optional
-  engine-url: https://www.google.co.uk/  # Url of the search engine you want to use
-  query-arg: search?q=  # The uri for the search (default is for google)
+skills:
+  - name: google-it
+    # Use Google search engine (Default)
+    engine-url: https://www.google.co.uk/
+    query-arg: search?q=
+    # Other search engines that can be used (keep only one uncommented at a time)
+    # Use Bing search engine
+#   engine-url: https://www.bing.com/
+#   query-arg: search?=
+    # Use DuckDuckGo search engine
+#   engine-url: https://duckduckgo.com/
+#   query-arg: ?q=
+    # Use Yahoo search engine
+#   engine-url: http://search.yahoo.com/
+#   query-arg: search?p=
+    # Use Aol search engine
+#   engine-url: https://search.aol.co.uk/aol/
+#   query-arg: search?query=
+    # Use Ask search engine
+#   engine-url: https://uk.ask.com/
+#   query-arg: web?q=
+    # Use Wolframalpha search engine
+#   engine-url: https://www.wolframalpha.com/input/
+#   query-arg: ?i=
 ```
 
 ## Usage


### PR DESCRIPTION
Other skills have the line **skills** before **-name** so I added it to keep all configuration examples the same.
I was unsure how to show the list of other engines but only keeping the default (Google) activated. In the end, I just commented the beginning of the line. Let me know if you would rather do this in some other way.