### PR TITLE
Updated regex to accept both google and search 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,9 +2,10 @@ import urllib.parse
 
 from opsdroid.matchers import match_regex
 
-@match_regex(r'^google (.*)')
+
+@match_regex(r'^(?:google|search) (.*)')
 async def hello(opsdroid, config, message):
     search_term = urllib.parse.quote_plus(message.regex.group(1))
-    google_url = config.get("engine-url", "https://www.google.co.uk/")
+    engine_url = config.get("engine-url", "https://www.google.co.uk/")
     query_arg = config.get("query-arg", "search?q=")
-    await message.respond("{}{}{}".format(google_url, query_arg, search_term))
+    await message.respond("Here's what I found {}{}{}".format(engine_url, query_arg, search_term))


### PR DESCRIPTION
Now both search and google can be used to search something

```
opsdroid> google this
Here's what I found https://www.bing.com/search?=this
opsdroid> search that
Here's what I found https://www.bing.com/search?=that
```
Changed configs to see if it still works with a different search engine and it does work as well.

I've also added some "personallity" to what opsdroid returns. Let me know if you rather have it return a single link like before.

